### PR TITLE
update actions/checkout@v4

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
         ruby-version: [2.7, 3.0, 3.1, head]
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         submodules: true
     - name: Set up Ruby

--- a/perfect_toml.gemspec
+++ b/perfect_toml.gemspec
@@ -31,4 +31,5 @@ END
   spec.bindir = "exe"
   spec.executables = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
+  spec.add_dependency 'ostruct'
 end


### PR DESCRIPTION
Ruby3でCIが落ちるので、その原因を探っていきます。